### PR TITLE
feat: allow plugin binary label

### DIFF
--- a/ecsact/extensions.bzl
+++ b/ecsact/extensions.bzl
@@ -30,7 +30,7 @@ package(default_visibility = ["//visibility:public"])
 ecsact_codegen_plugin(
     name = "cpp_header", 
     output_extension = "hh",
-    plugin = "cpp_header",
+    plugin_path = "cpp_header",
 )
 """
 

--- a/ecsact/private/ecsact_codegen_plugin.bzl
+++ b/ecsact/private/ecsact_codegen_plugin.bzl
@@ -8,10 +8,17 @@ EcsactCodegenPluginInfo = provider(
 )
 
 def _ecsact_codegen_plugin(ctx):
+    if ctx.attr.plugin and ctx.attr.plugin_path:
+        fail("Cannot supply both 'plugin' and 'plugin_path' for ecsact_codegen_plugin")
+
+    plugin_path = ctx.attr.plugin_path
+    if ctx.file.plugin:
+        plugin_path = ctx.file.plugin.path
+
     return [
         EcsactCodegenPluginInfo(
             output_extension = ctx.attr.output_extension,
-            plugin = ctx.attr.plugin,
+            plugin = plugin_path,
             data = [],
         ),
     ]
@@ -21,6 +28,7 @@ ecsact_codegen_plugin = rule(
     doc = "Bazel info necessary for ecsact codegen plugin to be used with `ecsact_codegen`. Default plugins are available at `@ecsact//codegen_plugins:*`.",
     attrs = {
         "output_extension": attr.string(mandatory = True, doc = "Plugin name. Also used as output file extension. This must match the extension specified by the plugin."),
-        "plugin": attr.string(mandatory = True, doc = "Path to plugin or name of builtin plugin."),
+        "plugin": attr.label(mandatory = False, allow_single_file = True, doc = "Label to plugin binary"),
+        "plugin_path": attr.string(mandatory = False, doc = "Path to plugin or name of builtin plugin."),
     },
 )


### PR DESCRIPTION
this is a breaking change, but the only place it was being used was the `ecsact_sdk` bazel repo which is in this repo. We can safely increment this as a patch.